### PR TITLE
Fixed the text below welcome image

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
             <br />
             <br />
             <div class="column">
-             
+             <br />
                 <font size="5"
                   ><h2 class="scp">
                     The finest ingredients are brought together with love and
@@ -284,8 +284,6 @@
                   ></font
                 >
             
-              <br />
-              <br />
               <br />
               <br />
 


### PR DESCRIPTION
**🛠️ Fixes Issue #113**

**Closes #113**

@flyingSaucer87 created a pull request for the issue, and now the text below the welcome image is aligned properly.

![image](https://user-images.githubusercontent.com/83328209/194579244-516ca908-ca3f-4139-a848-37728b2a1489.png)


